### PR TITLE
Cart system integration Firestore + Provider + SharedPreferences.

### DIFF
--- a/lib/core/providers/cart_provider.dart
+++ b/lib/core/providers/cart_provider.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/foundation.dart';
+import 'package:ecommerce_app/data/models/cart_item.dart';
+import 'package:ecommerce_app/data/services/cart_service.dart';
+
+class CartProvider extends ChangeNotifier {
+  final CartService _cartService = CartService();
+
+  // State variables
+  List<CartItem> _cartItems = [];
+  bool _isLoading = false;
+  String? _errorMessage;
+  double _cartTotal = 0.0;
+  double _cartSubtotal = 0.0;
+  int _itemCount = 0;
+
+  // Getters
+  List<CartItem> get cartItems => _cartItems;
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+  double get cartTotal => _cartTotal;
+  double get cartSubtotal => _cartSubtotal;
+  int get itemCount => _itemCount;
+  bool get isEmpty => _cartItems.isEmpty;
+  double get cartDiscount => _cartSubtotal - _cartTotal;
+
+  // Initialize cart - load data from SharedPreferences and listen to Firestore
+  Future<void> initializeCart() async {
+    _setLoading(true);
+    try {
+      // Load cached totals from SharedPreferences
+      await _loadCachedTotals();
+
+      // Listen to real-time cart updates from Firestore
+      _cartService.getCartStream().listen(
+        (cartItems) {
+          _cartItems = cartItems;
+          _updateTotals();
+          _setLoading(false);
+        },
+        onError: (error) {
+          _setError(error.toString());
+          _setLoading(false);
+        },
+      );
+    } catch (e) {
+      _setError(e.toString());
+      _setLoading(false);
+    }
+  }
+
+  // Add product to cart
+  Future<void> addToCart(dynamic product, int quantity) async {
+    try {
+      _clearError();
+
+      final cartItem = CartItem.fromProduct(product, quantity);
+      await _cartService.addToCart(cartItem);
+
+      // Update cached totals
+      await _loadCachedTotals();
+
+      // The stream listener will automatically update _cartItems
+    } catch (e) {
+      _setError(e.toString());
+      rethrow;
+    }
+  }
+
+  // Update item quantity
+  Future<void> updateQuantity(int productId, int newQuantity) async {
+    try {
+      _clearError();
+
+      await _cartService.updateItemQuantity(productId, newQuantity);
+
+      // Update cached totals
+      await _loadCachedTotals();
+
+      // The stream listener will automatically update _cartItems
+    } catch (e) {
+      _setError(e.toString());
+      rethrow;
+    }
+  }
+
+  // Increase quantity
+  Future<void> increaseQuantity(int productId) async {
+    final item = _cartItems.firstWhere(
+      (item) => item.productId == productId,
+      orElse: () => throw Exception('Item not found in cart'),
+    );
+
+    await updateQuantity(productId, item.quantity + 1);
+  }
+
+  // Decrease quantity
+  Future<void> decreaseQuantity(int productId) async {
+    final item = _cartItems.firstWhere(
+      (item) => item.productId == productId,
+      orElse: () => throw Exception('Item not found in cart'),
+    );
+
+    if (item.quantity > 1) {
+      await updateQuantity(productId, item.quantity - 1);
+    } else {
+      await removeFromCart(productId);
+    }
+  }
+
+  // Remove item from cart
+  Future<void> removeFromCart(int productId) async {
+    try {
+      _clearError();
+
+      await _cartService.removeFromCart(productId);
+
+      // Update cached totals
+      await _loadCachedTotals();
+
+      // The stream listener will automatically update _cartItems
+    } catch (e) {
+      _setError(e.toString());
+      rethrow;
+    }
+  }
+
+  // Clear entire cart
+  Future<void> clearCart() async {
+    try {
+      _clearError();
+
+      await _cartService.clearCart();
+
+      // Clear local state
+      _cartItems.clear();
+      _cartTotal = 0.0;
+      _cartSubtotal = 0.0;
+      _itemCount = 0;
+
+      notifyListeners();
+    } catch (e) {
+      _setError(e.toString());
+      rethrow;
+    }
+  }
+
+  // Check if product is in cart
+  bool isProductInCart(int productId) {
+    return _cartItems.any((item) => item.productId == productId);
+  }
+
+  // Get product quantity in cart
+  int getProductQuantity(int productId) {
+    try {
+      final item = _cartItems.firstWhere((item) => item.productId == productId);
+      return item.quantity;
+    } catch (e) {
+      return 0;
+    }
+  }
+
+  // Load cached totals from SharedPreferences
+  Future<void> _loadCachedTotals() async {
+    try {
+      _cartTotal = await _cartService.getCartTotal();
+      _cartSubtotal = await _cartService.getCartSubtotal();
+      _itemCount = await _cartService.getCartItemCount();
+      notifyListeners();
+    } catch (e) {
+      print('Error loading cached totals: $e');
+    }
+  }
+
+  // Update totals from current cart items
+  void _updateTotals() {
+    _cartSubtotal = 0;
+    _cartTotal = 0;
+    _itemCount = 0;
+
+    for (final item in _cartItems) {
+      _cartSubtotal += item.price * item.quantity;
+      _cartTotal += item.totalPrice;
+      _itemCount += item.quantity;
+    }
+
+    notifyListeners();
+  }
+
+  // Set loading state
+  void _setLoading(bool loading) {
+    _isLoading = loading;
+    notifyListeners();
+  }
+
+  // Set error message
+  void _setError(String message) {
+    _errorMessage = message;
+    notifyListeners();
+  }
+
+  // Clear error message
+  void _clearError() {
+    _errorMessage = null;
+    notifyListeners();
+  }
+
+  // Get cart summary for checkout
+  Map<String, dynamic> getCartSummary() {
+    return {
+      'items': _cartItems.map((item) => item?.toJson()).toList(),
+      'itemCount': _itemCount,
+      'subtotal': _cartSubtotal,
+      'discount': cartDiscount,
+      'total': _cartTotal,
+      'timestamp': DateTime.now().toIso8601String(),
+    };
+  }
+
+  // Calculate delivery fee (you can customize this logic)
+  double calculateDeliveryFee() {
+    if (_cartTotal >= 50) return 0.0; // Free delivery over $50
+    return 5.99; // Standard delivery fee
+  }
+
+  // Get final checkout total including delivery
+  double getFinalTotal() {
+    return _cartTotal + calculateDeliveryFee();
+  }
+}

--- a/lib/core/providers/nav_provider.dart
+++ b/lib/core/providers/nav_provider.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class NavProvider with ChangeNotifier {
+  int _index = 0;
+  int get index => _index;
+  void setIndex(int i) {
+    if (_index == i) return;
+    _index = i;
+    notifyListeners();
+  }
+}

--- a/lib/data/models/cart_item.dart
+++ b/lib/data/models/cart_item.dart
@@ -1,0 +1,111 @@
+class CartItem {
+  // Basic properties - the data we store for each cart item
+  final int productId; // Links to original product
+  final String title; // Product name
+  final double price; // Original price
+  final String thumbnail; // Product image URL
+  final double? discountPercentage; // Discount if available (can be null)
+  final String category; // Product category
+  final String brand; // Product brand
+  int quantity; // How many items (can change)
+  final DateTime addedAt; // When added to cart
+
+  // Constructor - creates a new CartItem
+  CartItem({
+    required this.productId,
+    required this.title,
+    required this.price,
+    required this.thumbnail,
+    this.discountPercentage, // Optional with ?
+    required this.category,
+    required this.brand,
+    required this.quantity,
+    required this.addedAt,
+  });
+
+  // METHOD 1: Calculate discounted price
+  // Why do we need this? Because we need to show the actual price after discount
+  double get discountedPrice {
+    if (discountPercentage != null) {
+      // Formula: price - (price × discount ÷ 100)
+      return price - (price * discountPercentage! / 100);
+    }
+    // If no discount, return original price
+    return price;
+  }
+
+  // METHOD 2: Calculate total price for this item
+  // Why do we need this? Because user can buy multiple quantities
+  double get totalPrice {
+    // Formula: discounted price × quantity
+    return discountedPrice * quantity;
+  }
+
+  // METHOD 3: Convert CartItem to JSON (for saving to Firestore)
+  // Why do we need this? Firestore stores data as JSON/Map
+  Map<String, dynamic> toJson() {
+    return {
+      'productId': productId,
+      'title': title,
+      'price': price,
+      'thumbnail': thumbnail,
+      'discountPercentage': discountPercentage,
+      'category': category,
+      'brand': brand,
+      'quantity': quantity,
+      // Convert DateTime to milliseconds for Firestore
+      'addedAt': addedAt.millisecondsSinceEpoch,
+    };
+  }
+
+  // METHOD 4: Create CartItem from JSON (for loading from Firestore)
+  // Why do we need this? When we read from Firestore, we get JSON/Map
+  factory CartItem.fromJson(Map<String, dynamic> json) {
+    return CartItem(
+      productId: json['productId'] ?? 0, // Use 0 if null
+      title: json['title'] ?? '', // Use empty string if null
+      price: (json['price'] ?? 0.0).toDouble(), // Ensure it's double
+      thumbnail: json['thumbnail'] ?? '',
+      discountPercentage: json['discountPercentage']?.toDouble(),
+      category: json['category'] ?? '',
+      brand: json['brand'] ?? '',
+      quantity: json['quantity'] ?? 1,
+      // Convert milliseconds back to DateTime
+      addedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['addedAt'] ?? DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+  }
+
+  // METHOD 5: Create CartItem from your Product object
+  // Why do we need this? When user adds product to cart, we convert Product → CartItem
+  factory CartItem.fromProduct(dynamic product, int quantity) {
+    return CartItem(
+      productId: product.id ?? 0,
+      title: product.title ?? '',
+      price: (product.price ?? 0.0).toDouble(),
+      thumbnail: product.thumbnail ?? '',
+      discountPercentage: product.discountPercentage?.toDouble(),
+      category: product.category ?? '',
+      brand: product.brand ?? '',
+      quantity: quantity, // User-selected quantity
+      addedAt: DateTime.now(), // Current timestamp
+    );
+  }
+
+  // METHOD 6: Create a copy with updated quantity
+  // Why do we need this? When user changes quantity, we need new CartItem
+  CartItem copyWith({int? quantity}) {
+    return CartItem(
+      productId: productId,
+      title: title,
+      price: price,
+      thumbnail: thumbnail,
+      discountPercentage: discountPercentage,
+      category: category,
+      brand: brand,
+      quantity: quantity ?? this.quantity, // Use new quantity or keep current
+      addedAt: addedAt, // Keep original add time
+    );
+  }
+}

--- a/lib/data/services/cart_service.dart
+++ b/lib/data/services/cart_service.dart
@@ -1,0 +1,286 @@
+import 'dart:convert';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/cart_item.dart';
+
+class CartService {
+  static final CartService _instance = CartService._internal();
+  factory CartService() => _instance;
+  CartService._internal();
+
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  // SharedPreferences keys
+  static const String _cartTotalKey = 'cart_total';
+  static const String _cartItemCountKey = 'cart_item_count';
+  static const String _cartSubtotalKey = 'cart_subtotal';
+
+  // Get current user ID
+  String? get _currentUserId => _auth.currentUser?.uid;
+
+  // Get cart collection reference for current user
+  CollectionReference<Map<String, dynamic>>? get _cartCollection {
+    if (_currentUserId == null) return null;
+    return _firestore
+        .collection('users')
+        .doc(_currentUserId)
+        .collection('cart');
+  }
+
+  // ==========================================
+  // FIRESTORE OPERATIONS
+  // ==========================================
+
+  // Add item to cart in Firestore
+  Future<void> addToCart(CartItem cartItem) async {
+    if (_cartCollection == null) {
+      throw Exception('User not authenticated');
+    }
+
+    try {
+      // Check if item already exists in cart
+      final querySnapshot = await _cartCollection!
+          .where('productId', isEqualTo: cartItem.productId)
+          .get();
+
+      if (querySnapshot.docs.isNotEmpty) {
+        // Item exists, update quantity
+        final doc = querySnapshot.docs.first;
+        final existingItem = CartItem.fromJson(doc.data());
+        final updatedQuantity = existingItem.quantity + cartItem.quantity;
+
+        await doc.reference.update({
+          'quantity': updatedQuantity,
+          'addedAt': DateTime.now().millisecondsSinceEpoch,
+        });
+      } else {
+        // Item doesn't exist, add new
+        await _cartCollection!.add(cartItem.toJson());
+      }
+
+      // Update SharedPreferences totals
+      await _updateCartTotals();
+    } catch (e) {
+      throw Exception('Failed to add item to cart: $e');
+    }
+  }
+
+  // Get all cart items from Firestore
+  Future<List<CartItem>> getCartItems() async {
+    if (_cartCollection == null) {
+      return [];
+    }
+
+    try {
+      final querySnapshot = await _cartCollection!
+          .orderBy('addedAt', descending: true)
+          .get();
+
+      return querySnapshot.docs
+          .map((doc) => CartItem.fromJson(doc.data()))
+          .toList();
+    } catch (e) {
+      throw Exception('Failed to get cart items: $e');
+    }
+  }
+
+  // Update item quantity in Firestore
+  Future<void> updateItemQuantity(int productId, int newQuantity) async {
+    if (_cartCollection == null) {
+      throw Exception('User not authenticated');
+    }
+
+    try {
+      if (newQuantity <= 0) {
+        await removeFromCart(productId);
+        return;
+      }
+
+      final querySnapshot = await _cartCollection!
+          .where('productId', isEqualTo: productId)
+          .get();
+
+      if (querySnapshot.docs.isNotEmpty) {
+        final doc = querySnapshot.docs.first;
+        await doc.reference.update({
+          'quantity': newQuantity,
+          'addedAt': DateTime.now().millisecondsSinceEpoch,
+        });
+
+        // Update SharedPreferences totals
+        await _updateCartTotals();
+      }
+    } catch (e) {
+      throw Exception('Failed to update item quantity: $e');
+    }
+  }
+
+  // Remove item from cart in Firestore
+  Future<void> removeFromCart(int productId) async {
+    if (_cartCollection == null) {
+      throw Exception('User not authenticated');
+    }
+
+    try {
+      final querySnapshot = await _cartCollection!
+          .where('productId', isEqualTo: productId)
+          .get();
+
+      for (final doc in querySnapshot.docs) {
+        await doc.reference.delete();
+      }
+
+      // Update SharedPreferences totals
+      await _updateCartTotals();
+    } catch (e) {
+      throw Exception('Failed to remove item from cart: $e');
+    }
+  }
+
+  // Clear entire cart
+  Future<void> clearCart() async {
+    if (_cartCollection == null) {
+      throw Exception('User not authenticated');
+    }
+
+    try {
+      final querySnapshot = await _cartCollection!.get();
+
+      for (final doc in querySnapshot.docs) {
+        await doc.reference.delete();
+      }
+
+      // Clear SharedPreferences
+      await _clearCartTotals();
+    } catch (e) {
+      throw Exception('Failed to clear cart: $e');
+    }
+  }
+
+  // Get cart stream for real-time updates
+  Stream<List<CartItem>> getCartStream() {
+    if (_cartCollection == null) {
+      return Stream.value([]);
+    }
+
+    return _cartCollection!
+        .orderBy('addedAt', descending: true)
+        .snapshots()
+        .map((snapshot) {
+          final items = snapshot.docs
+              .map((doc) => CartItem.fromJson(doc.data()))
+              .toList();
+
+          // Update SharedPreferences whenever cart changes
+          _updateCartTotals();
+
+          return items;
+        });
+  }
+
+  // ==========================================
+  // SHARED PREFERENCES OPERATIONS
+  // ==========================================
+
+  // Update cart totals in SharedPreferences
+  Future<void> _updateCartTotals() async {
+    try {
+      final cartItems = await getCartItems();
+      final prefs = await SharedPreferences.getInstance();
+
+      double subtotal = 0;
+      double total = 0;
+      int itemCount = 0;
+
+      for (final item in cartItems) {
+        subtotal += item.price * item.quantity;
+        total += item.totalPrice; // This includes discount
+        itemCount += item.quantity;
+      }
+
+      await prefs.setDouble(_cartSubtotalKey, subtotal);
+      await prefs.setDouble(_cartTotalKey, total);
+      await prefs.setInt(_cartItemCountKey, itemCount);
+    } catch (e) {
+      print('Error updating cart totals: $e');
+    }
+  }
+
+  // Get cart total from SharedPreferences
+  Future<double> getCartTotal() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getDouble(_cartTotalKey) ?? 0.0;
+  }
+
+  // Get cart subtotal from SharedPreferences
+  Future<double> getCartSubtotal() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getDouble(_cartSubtotalKey) ?? 0.0;
+  }
+
+  // Get cart item count from SharedPreferences
+  Future<int> getCartItemCount() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_cartItemCountKey) ?? 0;
+  }
+
+  // Clear cart totals from SharedPreferences
+  Future<void> _clearCartTotals() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_cartTotalKey);
+    await prefs.remove(_cartSubtotalKey);
+    await prefs.remove(_cartItemCountKey);
+  }
+
+  // ==========================================
+  // UTILITY METHODS
+  // ==========================================
+
+  // Check if product is in cart
+  Future<bool> isProductInCart(int productId) async {
+    if (_cartCollection == null) return false;
+
+    try {
+      final querySnapshot = await _cartCollection!
+          .where('productId', isEqualTo: productId)
+          .get();
+
+      return querySnapshot.docs.isNotEmpty;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // Get product quantity in cart
+  Future<int> getProductQuantityInCart(int productId) async {
+    if (_cartCollection == null) return 0;
+
+    try {
+      final querySnapshot = await _cartCollection!
+          .where('productId', isEqualTo: productId)
+          .get();
+
+      if (querySnapshot.docs.isNotEmpty) {
+        final item = CartItem.fromJson(querySnapshot.docs.first.data());
+        return item.quantity;
+      }
+
+      return 0;
+    } catch (e) {
+      return 0;
+    }
+  }
+
+  // Calculate cart discount
+  Future<double> getCartDiscount() async {
+    try {
+      final subtotal = await getCartSubtotal();
+      final total = await getCartTotal();
+      return subtotal - total;
+    } catch (e) {
+      return 0.0;
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:ecommerce_app/core/constants/app_colors.dart';
+import 'package:ecommerce_app/core/providers/cart_provider.dart';
+import 'package:ecommerce_app/core/providers/nav_provider.dart';
 import 'package:ecommerce_app/core/providers/theme_provider.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
@@ -18,34 +20,27 @@ void main() async {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // @override
-  // Widget build(BuildContext context) {
-  //   return MaterialApp(
-  //     title: 'E-Shop',
-  //     debugShowCheckedModeBanner: false,
-  //     theme: AppTheme.lightTheme,
-  //     // Route Configuration
-  //     initialRoute: RoutesName.getStartedScreen,
-  //     onGenerateRoute: Routes.generateRoute,
-  //   );
-  // }
-
+  @override
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (context) => ThemeProvider(),
+    return MultiProvider(
+      providers: [
+        // Your existing providers...
+        ChangeNotifierProvider(create: (_) => NavProvider()),
+
+        ChangeNotifierProvider(create: (_) => CartProvider()..initializeCart()),
+        ChangeNotifierProvider(create: (_) => ThemeProvider()),
+      ],
       child: Consumer<ThemeProvider>(
-        builder: (context, themeProvider, child) {
-          return MaterialApp(
-            title: 'E-Commerce App',
-            debugShowCheckedModeBanner: false,
-            themeMode: themeProvider.themeMode,
-            theme: AppTheme.lightTheme, // Your existing light theme
-            darkTheme: AppTheme.darkTheme, // New dark theme
-            initialRoute: RoutesName.getStartedScreen,
-            onGenerateRoute: Routes.generateRoute,
-          );
-        },
+        builder: (context, themeProvider, _) => MaterialApp(
+          title: 'E-Commerce App',
+          debugShowCheckedModeBanner: false,
+          themeMode: themeProvider.themeMode,
+          theme: AppTheme.lightTheme, // your light theme
+          darkTheme: AppTheme.darkTheme, // your dark theme
+          initialRoute: RoutesName.getStartedScreen,
+          onGenerateRoute: Routes.generateRoute,
+        ),
       ),
     );
   }

--- a/lib/presentation/screens/cart/cart_screen.dart
+++ b/lib/presentation/screens/cart/cart_screen.dart
@@ -1,53 +1,531 @@
+import 'package:ecommerce_app/core/providers/cart_provider.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../../core/constants/app_colors.dart';
+import '../../../data/models/cart_item.dart';
 
-class CartScreen extends StatelessWidget {
+class CartScreen extends StatefulWidget {
   const CartScreen({super.key});
+
+  @override
+  State<CartScreen> createState() => _CartScreenState();
+}
+
+class _CartScreenState extends State<CartScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Initialize cart when screen loads
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<CartProvider>().initializeCart();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.backgroundColor,
-      appBar: AppBar(
-        backgroundColor: AppColors.surfaceColor,
-        automaticallyImplyLeading: false,
-        elevation: 2,
-        shadowColor: AppColors.lightShadow,
-        title: Text(
-          'Shopping Cart',
-          style: TextStyle(
-            color: AppColors.primaryColor,
-            fontSize: 26,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-        centerTitle: true,
+      appBar: _buildAppBar(),
+      body: Consumer<CartProvider>(
+        builder: (context, cartProvider, _) {
+          if (cartProvider.isLoading) return _buildLoadingState();
+          if (cartProvider.isEmpty) return _buildEmptyState();
+          return _buildCartContent(cartProvider);
+        },
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+    );
+  }
+
+  PreferredSizeWidget _buildAppBar() {
+    final canPop = Navigator.of(context).canPop();
+    return AppBar(
+      backgroundColor: AppColors.surfaceColor,
+      elevation: 2,
+      automaticallyImplyLeading: false, // don't auto-add a back button
+      shadowColor: AppColors.lightShadow,
+      leading: canPop
+          ? IconButton(
+              icon: Icon(Icons.arrow_back, color: AppColors.primaryColor),
+              onPressed: () =>
+                  Navigator.of(context).pop(), // safe because canPop
+            )
+          : null,
+      title: Consumer<CartProvider>(
+        builder: (_, cartProvider, __) => Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Icon(
-              Icons.shopping_cart_outlined,
-              size: 80,
-              color: AppColors.textTertiary,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Your Cart',
+            const Text(
+              'Shopping Cart',
               style: TextStyle(
                 color: AppColors.textPrimary,
-                fontSize: 24,
+                fontSize: 18,
                 fontWeight: FontWeight.bold,
               ),
             ),
-            const SizedBox(height: 8),
-            Text(
-              'Your selected items will appear here',
-              style: TextStyle(color: AppColors.textSecondary, fontSize: 16),
+            if (cartProvider.itemCount > 0)
+              Text(
+                '${cartProvider.itemCount} items',
+                style: TextStyle(color: AppColors.textSecondary, fontSize: 12),
+              ),
+          ],
+        ),
+      ),
+      actions: [
+        Consumer<CartProvider>(
+          builder: (_, cartProvider, __) {
+            if (cartProvider.cartItems.isEmpty) return const SizedBox.shrink();
+            return TextButton(
+              onPressed: () => _showClearCartDialog(cartProvider),
+              child: Text(
+                'Clear',
+                style: TextStyle(
+                  color: AppColors.errorColor,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLoadingState() {
+    return const Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          CircularProgressIndicator(color: AppColors.primaryColor),
+          SizedBox(height: 16),
+          Text('Loading your cart...'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.shopping_cart_outlined,
+            size: 80,
+            color: AppColors.textTertiary,
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Your cart is empty',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: AppColors.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Add some products to get started!',
+            style: TextStyle(fontSize: 14, color: AppColors.textSecondary),
+          ),
+          const SizedBox(height: 24),
+          ElevatedButton.icon(
+            onPressed: () async {
+              await Navigator.of(
+                context,
+              ).maybePop(); // safe pop; does nothing at tab root
+              // (Optional) If you want to jump to Home tab here, see the note below.
+            },
+            icon: const Icon(Icons.shopping_bag),
+            label: const Text('Continue Shopping'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.primaryColor,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCartContent(CartProvider cartProvider) {
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: cartProvider.cartItems.length,
+            itemBuilder: (_, index) {
+              final item = cartProvider.cartItems[index];
+              return _buildCartItemCard(item, cartProvider);
+            },
+          ),
+        ),
+        _buildCartSummary(cartProvider),
+      ],
+    );
+  }
+
+  Widget _buildCartItemCard(CartItem item, CartProvider cartProvider) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      elevation: 2,
+      color: AppColors.surfaceColor,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Image
+            ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: Image.network(
+                item.thumbnail,
+                width: 80,
+                height: 80,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => Container(
+                  width: 80,
+                  height: 80,
+                  color: Colors.grey[200],
+                  child: const Icon(Icons.image_not_supported),
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+
+            // Details
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Title
+                  Text(
+                    item.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.textPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  // Meta
+                  Text(
+                    '${item.brand} • ${item.category}',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: AppColors.textSecondary,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+
+                  // Price row
+                  Row(
+                    children: [
+                      if (item.discountPercentage != null) ...[
+                        Text(
+                          '\$${item.discountedPrice.toStringAsFixed(2)}',
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                            color: AppColors.primaryColor,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          '\$${item.price.toStringAsFixed(2)}',
+                          style: const TextStyle(
+                            fontSize: 14,
+                            color: Colors.grey,
+                            decoration: TextDecoration.lineThrough,
+                          ),
+                        ),
+                      ] else
+                        Text(
+                          '\$${item.price.toStringAsFixed(2)}',
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                            color: AppColors.primaryColor,
+                          ),
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+
+                  // Quantity + Remove
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      // Qty controls
+                      Container(
+                        decoration: BoxDecoration(
+                          border: Border.all(color: Colors.grey[300]!),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            SizedBox(
+                              width: 32,
+                              height: 32,
+                              child: IconButton(
+                                padding: EdgeInsets.zero,
+                                icon: const Icon(Icons.remove, size: 16),
+                                onPressed: () => _updateQuantity(
+                                  cartProvider,
+                                  item,
+                                  item.quantity - 1,
+                                ),
+                              ),
+                            ),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                              ),
+                              child: Text(
+                                '${item.quantity}',
+                                style: const TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 14,
+                                ),
+                              ),
+                            ),
+                            SizedBox(
+                              width: 32,
+                              height: 32,
+                              child: IconButton(
+                                padding: EdgeInsets.zero,
+                                icon: const Icon(Icons.add, size: 16),
+                                onPressed: () => _updateQuantity(
+                                  cartProvider,
+                                  item,
+                                  item.quantity + 1,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      // Remove
+                      IconButton(
+                        icon: Icon(
+                          Icons.delete_outline,
+                          color: AppColors.errorColor,
+                        ),
+                        onPressed: () => _removeItem(cartProvider, item),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+
+                  // Line total
+                  Text(
+                    'Total: \$${item.totalPrice.toStringAsFixed(2)}',
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.textSecondary,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildCartSummary(CartProvider cartProvider) {
+    final deliveryFee = cartProvider.calculateDeliveryFee();
+    final finalTotal = cartProvider.getFinalTotal();
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceColor,
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.lightShadow,
+            blurRadius: 10,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          _buildSummaryRow(
+            'Subtotal',
+            '\$${cartProvider.cartSubtotal.toStringAsFixed(2)}',
+          ),
+          if (cartProvider.cartDiscount > 0)
+            _buildSummaryRow(
+              'Discount',
+              '-\$${cartProvider.cartDiscount.toStringAsFixed(2)}',
+              color: AppColors.successColor,
+            ),
+          _buildSummaryRow(
+            'Delivery',
+            deliveryFee == 0 ? 'FREE' : '\$${deliveryFee.toStringAsFixed(2)}',
+            color: deliveryFee == 0 ? AppColors.successColor : null,
+          ),
+          const Divider(height: 24),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                'Total',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: AppColors.textPrimary,
+                ),
+              ),
+              Text(
+                '\$${finalTotal.toStringAsFixed(2)}',
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: AppColors.primaryColor,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            height: 50,
+            child: ElevatedButton.icon(
+              onPressed: () => _proceedToCheckout(cartProvider),
+              icon: const Icon(Icons.payment),
+              label: const Text(
+                'Proceed to Checkout',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              ),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primaryColor,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                elevation: 2,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSummaryRow(String label, String value, {Color? color}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            label,
+            style: TextStyle(fontSize: 14, color: AppColors.textSecondary),
+          ),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: color ?? AppColors.textPrimary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _updateQuantity(
+    CartProvider cartProvider,
+    CartItem item,
+    int newQuantity,
+  ) {
+    if (newQuantity <= 0) {
+      _removeItem(cartProvider, item);
+    } else {
+      cartProvider.updateQuantity(item.productId, newQuantity);
+    }
+  }
+
+  void _removeItem(CartProvider cartProvider, CartItem item) {
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Remove Item'),
+        content: Text('Remove ${item.title} from your cart?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+              cartProvider.removeFromCart(item.productId);
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('${item.title} removed from cart'),
+                  backgroundColor: AppColors.infoColor,
+                ),
+              );
+            },
+            child: Text(
+              'Remove',
+              style: TextStyle(color: AppColors.errorColor),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showClearCartDialog(CartProvider cartProvider) {
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Clear Cart'),
+        content: const Text(
+          'Are you sure you want to remove all items from your cart?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+              cartProvider.clearCart();
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Cart cleared'),
+                  backgroundColor: AppColors.infoColor,
+                ),
+              );
+            },
+            child: Text('Clear', style: TextStyle(color: AppColors.errorColor)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _proceedToCheckout(CartProvider cartProvider) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          'Proceeding to checkout with ${cartProvider.itemCount} items',
+        ),
+        backgroundColor: AppColors.successColor,
       ),
     );
   }

--- a/lib/presentation/widgets/product_action_buttons.dart
+++ b/lib/presentation/widgets/product_action_buttons.dart
@@ -1,82 +1,128 @@
 import 'package:flutter/material.dart';
-import '../../../core/constants/app_colors.dart';
+import '../../core/constants/app_colors.dart';
 
 class ProductActionButtons extends StatelessWidget {
-  final VoidCallback onAddToCart;
-  final VoidCallback onBuyNow;
-  final VoidCallback onWishlistTap;
-  final bool isFavorite;
-
   const ProductActionButtons({
     super.key,
-    required this.onAddToCart,
-    required this.onBuyNow,
     required this.onWishlistTap,
-    this.isFavorite = false,
+    required this.isFavorite,
+    this.onAddToCart,
+    this.onBuyNow,
+    this.isInCart = false,
+    this.quantityInCart = 0,
+    this.isLoading = false,
   });
+
+  final VoidCallback? onAddToCart;
+  final VoidCallback? onBuyNow;
+  final VoidCallback onWishlistTap;
+
+  final bool isFavorite;
+  final bool isInCart;
+  final int quantityInCart;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
       decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
+        color: AppColors.surfaceColor,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.05),
+            color: AppColors.shadowColor,
             blurRadius: 10,
             offset: const Offset(0, -2),
           ),
         ],
       ),
-      child: Row(
-        children: [
-          // Wishlist / Favorite Icon
-          InkWell(
-            onTap: onWishlistTap,
-            borderRadius: BorderRadius.circular(12),
-            child: Container(
-              padding: const EdgeInsets.all(12),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          children: [
+            // Wishlist button
+            Container(
               decoration: BoxDecoration(
-                color: Theme.of(context).dividerColor.withOpacity(0.1),
+                color: AppColors.backgroundColor,
                 borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: AppColors.lightShadow),
               ),
-              child: Icon(
-                isFavorite ? Icons.favorite : Icons.favorite_outline,
-                color: isFavorite
-                    ? AppColors.errorColor
-                    : Theme.of(context).iconTheme.color,
+              child: IconButton(
+                onPressed: isLoading ? null : onWishlistTap,
+                icon: Icon(
+                  isFavorite ? Icons.favorite : Icons.favorite_border,
+                  color: isFavorite
+                      ? AppColors.errorColor
+                      : AppColors.textSecondary,
+                ),
+                tooltip: isFavorite
+                    ? 'Remove from wishlist'
+                    : 'Add to wishlist',
               ),
             ),
-          ),
+            const SizedBox(width: 12),
 
-          const SizedBox(width: 12),
-
-          // Add to Cart Button
-          Expanded(
-            child: ElevatedButton(
-              onPressed: onAddToCart,
-              style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 16),
+            // Add to Cart
+            Expanded(
+              child: SizedBox(
+                height: 50,
+                child: ElevatedButton.icon(
+                  onPressed: (onAddToCart == null || isLoading)
+                      ? null
+                      : onAddToCart,
+                  icon: isLoading
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        )
+                      : const Icon(Icons.shopping_cart),
+                  label: Text(
+                    isInCart && quantityInCart > 0
+                        ? 'Update Cart'
+                        : 'Add to Cart',
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.primaryColor,
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    elevation: 2,
+                  ),
+                ),
               ),
-              child: const Text('Add to Cart'),
             ),
-          ),
+            const SizedBox(width: 12),
 
-          const SizedBox(width: 12),
-
-          // Buy Now Button
-          Expanded(
-            child: ElevatedButton(
-              onPressed: onBuyNow,
-              style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                backgroundColor: AppColors.primaryColor,
+            // Buy Now
+            Expanded(
+              child: SizedBox(
+                height: 50,
+                child: ElevatedButton.icon(
+                  onPressed: (onBuyNow == null || isLoading) ? null : onBuyNow,
+                  icon: const Icon(Icons.flash_on),
+                  label: const Text(
+                    'Buy Now',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.accentColor,
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    elevation: 2,
+                  ),
+                ),
               ),
-              child: const Text('Buy Now'),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Implements a complete, user-scoped cart with real-time Firestore updates, Provider state management, and SharedPreferences caching for fast totals. Wires Add to Cart / Buy Now from the Product Detail screen, introduces a reusable ProductActionButtons widget, and adds NavProvider to switch bottom tabs (fixing the Cart tab “pop root” crash).

What changed

Data model

cart_item.dart: Cart line model with price math (discountedPrice, totalPrice), (de)serialization (toJson, fromJson, fromProduct), and copyWith.

Service (Firestore + cache)

cart_service.dart: Singleton service for all cart I/O.

Firestore: addToCart, updateItemQuantity, removeFromCart, clearCart, getCartItems, getCartStream.

SharedPreferences: caches subtotal, total, itemCount for instant UI and offline friendliness.

Utilities: isProductInCart, getProductQuantityInCart, getCartDiscount.

State management

cart_provider.dart (ChangeNotifier):

initializeCart() loads cached totals, subscribes to Firestore stream.

Actions: addToCart, updateQuantity, increaseQuantity, decreaseQuantity, removeFromCart, clearCart.

Derivations: cartItems, itemCount, cartSubtotal, cartTotal, cartDiscount, isEmpty, isLoading.

UI: Cart

cart_screen.dart: Renders loading/empty/content, per-item cards (image, discount-aware pricing, qty controls, remove), summary (subtotal/discount/delivery/total), checkout CTA. Safe nav (no popping tab root).

UI: Product

product_detail_screen.dart (previous file updated):

App bar cart badge (via CartProvider).

Bottom sheet quantity selector with stock validation + live total.

Hooks CartProvider.addToCart and uses tab switch to Cart via NavProvider (no extra /cart push).

UI: Reusable

product_action_buttons.dart: Reusable bottom action bar with onAddToCart, onBuyNow, onWishlistTap, isFavorite, isInCart, quantityInCart, isLoading.

Navigation

NEW nav_provider.dart: Minimal provider to hold selected bottom tab index and notify listeners.

MainNavigation: updated to use NavProvider for tab switching; each tab keeps its own Navigator stack; re-tap pops to root; back behavior consistent.

Files

lib/data/models/cart_item.dart

lib/data/services/cart_service.dart

lib/data/providers/cart_provider.dart

lib/presentation/screens/cart/cart_screen.dart

lib/presentation/screens/product/product_detail_screen.dart

lib/presentation/widgets/product_action_buttons.dart

lib/core/providers/nav_provider.dart (new)

lib/presentation/main_navigation.dart (updated to use NavProvider)