### PR TITLE
Wishlist: add New Items section + global ProductRepository

### DIFF
--- a/lib/core/providers/wishlist_provider.dart
+++ b/lib/core/providers/wishlist_provider.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+import 'package:ecommerce_app/data/models/wishlist_item.dart';
+import 'package:ecommerce_app/data/services/wishlist_service.dart';
+import 'package:flutter/foundation.dart';
+
+class WishlistProvider with ChangeNotifier {
+  final _svc = WishlistService();
+
+  List<WishlistItem> _items = [];
+  bool _loading = false;
+  String? _error;
+  StreamSubscription? _sub;
+
+  List<WishlistItem> get items => _items;
+  bool get isLoading => _loading;
+  String? get error => _error;
+
+  void initialize() {
+    _loading = true;
+    notifyListeners();
+
+    _sub?.cancel();
+    _sub = _svc.stream().listen(
+      (list) {
+        _items = list;
+        _loading = false;
+        _error = null;
+        notifyListeners();
+      },
+      onError: (e) {
+        _loading = false;
+        _error = e.toString();
+        notifyListeners();
+      },
+    );
+  }
+
+  bool isInWishlist(int productId) {
+    return _items.any((w) => w.productId == productId);
+  }
+
+  Future<void> toggle(dynamic product) async {
+    try {
+      await _svc.toggle(product);
+    } catch (e) {
+      _error = e.toString();
+      notifyListeners();
+      rethrow;
+    }
+  }
+
+  Future<void> add(dynamic product) async {
+    try {
+      await _svc.add(WishlistItem.fromProduct(product));
+    } catch (e) {
+      _error = e.toString();
+      notifyListeners();
+      rethrow;
+    }
+  }
+
+  Future<void> remove(int productId) async {
+    try {
+      await _svc.remove(productId);
+    } catch (e) {
+      _error = e.toString();
+      notifyListeners();
+      rethrow;
+    }
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/core/utils/text_utils.dart
+++ b/lib/core/utils/text_utils.dart
@@ -1,0 +1,19 @@
+class TextUtils {
+  /// Returns the first [maxWords] words of [text].
+  /// Adds [ellipsis] at the end when the title had more words.
+  static String truncateWords(
+    String text, {
+    int maxWords = 2,
+    String ellipsis = ' ..',
+    bool alwaysEllipsis = false, // set true if you ALWAYS want the suffix
+  }) {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return '';
+
+    final words = trimmed.split(RegExp(r'\s+')); // split on any whitespace
+    if (words.length <= maxWords) {
+      return alwaysEllipsis ? (words.join(' ') + ellipsis) : words.join(' ');
+    }
+    return words.take(maxWords).join(' ') + ellipsis;
+  }
+}

--- a/lib/data/models/wishlist_item.dart
+++ b/lib/data/models/wishlist_item.dart
@@ -1,0 +1,53 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class WishlistItem {
+  final int productId;
+  final String title;
+  final String thumbnail;
+  final double price;
+  final DateTime addedAt;
+
+  WishlistItem({
+    required this.productId,
+    required this.title,
+    required this.thumbnail,
+    required this.price,
+    required this.addedAt,
+  });
+
+  factory WishlistItem.fromProduct(dynamic product) {
+    return WishlistItem(
+      productId: (product.id ?? 0) as int,
+      title: (product.title ?? '') as String,
+      thumbnail: (product.thumbnail ?? '') as String,
+      price: ((product.price ?? 0.0) as num).toDouble(),
+      addedAt: DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'productId': productId,
+      'title': title,
+      'thumbnail': thumbnail,
+      'price': price,
+      'addedAt': FieldValue.serverTimestamp(), // server time for ordering
+    };
+  }
+
+  factory WishlistItem.fromJson(Map<String, dynamic> json) {
+    DateTime parseAddedAt(dynamic v) {
+      if (v is Timestamp) return v.toDate();
+      if (v is int) return DateTime.fromMillisecondsSinceEpoch(v);
+      return DateTime.now();
+    }
+
+    return WishlistItem(
+      productId: (json['productId'] ?? 0) as int,
+      title: (json['title'] ?? '') as String,
+      thumbnail: (json['thumbnail'] ?? '') as String,
+      price: ((json['price'] ?? 0.0) as num).toDouble(),
+      addedAt: parseAddedAt(json['addedAt']),
+    );
+  }
+}

--- a/lib/data/services/wishlist_service.dart
+++ b/lib/data/services/wishlist_service.dart
@@ -1,0 +1,77 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../models/wishlist_item.dart';
+
+class WishlistService {
+  static final WishlistService _instance = WishlistService._internal();
+  factory WishlistService() => _instance;
+  WishlistService._internal();
+
+  final _firestore = FirebaseFirestore.instance;
+  final _auth = FirebaseAuth.instance;
+
+  String? get _uid => _auth.currentUser?.uid;
+
+  CollectionReference<Map<String, dynamic>>? get _col {
+    final uid = _uid;
+    if (uid == null) return null;
+    return _firestore.collection('users').doc(uid).collection('wishlist');
+  }
+
+  // Add (upsert) a wishlist item
+  Future<void> add(WishlistItem item) async {
+    final col = _col;
+    if (col == null) throw Exception('User not authenticated');
+    final docRef = col.doc(item.productId.toString());
+    await docRef.set(item.toJson(), SetOptions(merge: true));
+  }
+
+  // Remove by productId
+  Future<void> remove(int productId) async {
+    final col = _col;
+    if (col == null) throw Exception('User not authenticated');
+    await col.doc(productId.toString()).delete();
+  }
+
+  // Toggle by product object
+  Future<void> toggle(dynamic product) async {
+    final col = _col;
+    if (col == null) throw Exception('User not authenticated');
+    final id = (product.id ?? 0) as int;
+    final ref = col.doc(id.toString());
+    final snap = await ref.get();
+    if (snap.exists) {
+      await ref.delete();
+    } else {
+      await ref.set(WishlistItem.fromProduct(product).toJson());
+    }
+  }
+
+  // Is product in wishlist?
+  Future<bool> isInWishlist(int productId) async {
+    final col = _col;
+    if (col == null) return false;
+    final snap = await col.doc(productId.toString()).get();
+    return snap.exists;
+  }
+
+  // Stream for real-time UI
+  Stream<List<WishlistItem>> stream() {
+    final col = _col;
+    if (col == null) return Stream.value([]);
+    return col
+        .orderBy('addedAt', descending: true)
+        .snapshots()
+        .map(
+          (s) => s.docs.map((d) => WishlistItem.fromJson(d.data())).toList(),
+        );
+  }
+
+  // One-shot fetch (if needed)
+  Future<List<WishlistItem>> getAll() async {
+    final col = _col;
+    if (col == null) return [];
+    final q = await col.orderBy('addedAt', descending: true).get();
+    return q.docs.map((d) => WishlistItem.fromJson(d.data())).toList();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,10 @@
 import 'package:ecommerce_app/core/constants/app_colors.dart';
+import 'package:ecommerce_app/core/network/api_client.dart';
 import 'package:ecommerce_app/core/providers/cart_provider.dart';
 import 'package:ecommerce_app/core/providers/nav_provider.dart';
 import 'package:ecommerce_app/core/providers/theme_provider.dart';
+import 'package:ecommerce_app/core/providers/wishlist_provider.dart';
+import 'package:ecommerce_app/data/repositories/product_repository.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -25,11 +28,18 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
+        Provider<ApiClient>(create: (_) => const ApiClient()),
+
+        // Create ONE ProductRepository derived from ApiClient
+        ProxyProvider<ApiClient, ProductRepository>(
+          update: (_, api, __) => ProductRepository(api),
+        ),
+
         // Your existing providers...
         ChangeNotifierProvider(create: (_) => NavProvider()),
-
-        ChangeNotifierProvider(create: (_) => CartProvider()..initializeCart()),
         ChangeNotifierProvider(create: (_) => ThemeProvider()),
+        ChangeNotifierProvider(create: (_) => CartProvider()..initializeCart()),
+        ChangeNotifierProvider(create: (_) => WishlistProvider()..initialize()),
       ],
       child: Consumer<ThemeProvider>(
         builder: (context, themeProvider, _) => MaterialApp(

--- a/lib/presentation/screens/home/home_screen.dart
+++ b/lib/presentation/screens/home/home_screen.dart
@@ -42,10 +42,15 @@ class _HomeScreenState extends State {
   void initState() {
     super.initState();
     // Create repositories
-    final apiClient = const ApiClient();
-    _categoryRepo = CategoryRepository(apiClient);
-    _productRepo = ProductRepository(apiClient);
+    //final apiClient = const ApiClient();
+    //_categoryRepo = CategoryRepository(apiClient);
+    //_productRepo = ProductRepository(apiClient);
 
+    // If you kept CategoryRepository local, keep this line:
+    final apiClient = context.read<ApiClient>(); // reuse global client
+    _categoryRepo = CategoryRepository(apiClient);
+
+    _productRepo = context.read<ProductRepository>();
     // Start data fetching
     _categoriesFuture = _categoryRepo.fetchTopCategoriesWithPreviews(
       categoryLimit: 6,

--- a/lib/presentation/screens/product/product_detail_screen.dart
+++ b/lib/presentation/screens/product/product_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:ecommerce_app/core/providers/cart_provider.dart';
+import 'package:ecommerce_app/core/providers/wishlist_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../core/constants/app_colors.dart';
@@ -210,14 +211,13 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
               bottom: 0,
               left: 0,
               right: 0,
-              child: Consumer<CartProvider>(
-                builder: (context, cartProvider, child) {
-                  final isInCart = cartProvider.isProductInCart(
-                    widget.product.id ?? 0,
-                  );
-                  final quantityInCart = cartProvider.getProductQuantity(
-                    widget.product.id ?? 0,
-                  );
+              child: Consumer2<CartProvider, WishlistProvider>(
+                builder: (context, cart, wish, child) {
+                  final productId = widget.product.id ?? 0;
+
+                  final isInCart = cart.isProductInCart(productId);
+                  final quantityInCart = cart.getProductQuantity(productId);
+                  final isFav = wish.isInWishlist(productId);
 
                   return ProductActionButtons(
                     onAddToCart: (widget.product.stock ?? 0) > 0
@@ -226,12 +226,16 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
                     onBuyNow: (widget.product.stock ?? 0) > 0
                         ? () => _openBottomSheet(action: 'buy')
                         : null,
-                    onWishlistTap: () {
-                      setState(() {
-                        _isFavorite = !_isFavorite;
-                      });
+
+                    //  Wishlist toggle now goes through the provider (persists in Firestore)
+                    onWishlistTap: () async {
+                      await context.read<WishlistProvider>().toggle(
+                        widget.product,
+                      );
                     },
-                    isFavorite: _isFavorite,
+
+                    // UI state comes from providers
+                    isFavorite: isFav,
                     isInCart: isInCart,
                     quantityInCart: quantityInCart,
                     isLoading: _isLoading,

--- a/lib/presentation/screens/wishlist/wishlist_screen.dart
+++ b/lib/presentation/screens/wishlist/wishlist_screen.dart
@@ -1,52 +1,501 @@
+import 'package:ecommerce_app/presentation/widgets/new_items_section.dart';
 import 'package:flutter/material.dart';
-import '../../../core/constants/app_colors.dart';
+import 'package:provider/provider.dart';
 
-class WishlistScreen extends StatelessWidget {
+import '../../../core/constants/app_colors.dart';
+import '../../../core/utils/text_utils.dart';
+import 'package:ecommerce_app/core/providers/wishlist_provider.dart';
+
+// read shared repo provided in main.dart
+import '../../../data/repositories/product_repository.dart';
+
+class WishlistScreen extends StatefulWidget {
   const WishlistScreen({super.key});
 
   @override
+  State<WishlistScreen> createState() => _WishlistScreenState();
+}
+
+class _WishlistScreenState extends State<WishlistScreen>
+    with TickerProviderStateMixin {
+  late final ProductRepository _productRepo;
+  late AnimationController _heartAnimationController;
+  late Animation<double> _heartAnimation;
+
+  final _scroll = ScrollController();
+  bool _firstBlockShown = false;
+  bool _newReady = false;
+  bool _postFrameChecked = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _productRepo = context.read<ProductRepository>();
+    _scroll.addListener(_maybeStartLazyNewItems);
+
+    // Heart animation setup
+    _heartAnimationController = AnimationController(
+      duration: const Duration(seconds: 2),
+      vsync: this,
+    );
+    _heartAnimation = Tween<double>(begin: 0.8, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _heartAnimationController,
+        curve: Curves.easeInOut,
+      ),
+    );
+
+    // Start heart animation
+    _heartAnimationController.repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    _heartAnimationController.dispose();
+    super.dispose();
+  }
+
+  void _maybeStartLazyNewItems() {
+    if (!_firstBlockShown) return;
+    final offset = _scroll.position.pixels;
+    final vp = _scroll.position.viewportDimension;
+
+    if (!_newReady && offset > vp * 0.40) {
+      setState(() => _newReady = true);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
     return Scaffold(
-      backgroundColor: AppColors.backgroundColor,
+      backgroundColor: isDark
+          ? AppColors.darkBackgroundColor
+          : AppColors.backgroundColor,
       appBar: AppBar(
-        backgroundColor: AppColors.surfaceColor,
+        backgroundColor: isDark
+            ? AppColors.darkSurfaceColor
+            : AppColors.surfaceColor,
         automaticallyImplyLeading: false,
-        elevation: 2,
-        shadowColor: AppColors.lightShadow,
+        elevation: 0,
         title: Text(
-          'Wishlist',
+          'My Wishlist',
           style: TextStyle(
-            color: AppColors.primaryColor,
-            fontSize: 26,
+            color: isDark ? AppColors.darkTextPrimary : AppColors.primaryColor,
+            fontSize: 24,
             fontWeight: FontWeight.bold,
           ),
         ),
         centerTitle: true,
+        actions: [
+          Consumer<WishlistProvider>(
+            builder: (context, wish, _) {
+              if (wish.items.isNotEmpty && !wish.isLoading) {
+                return Row(
+                  children: [
+                    // Item count badge
+                    Container(
+                      margin: const EdgeInsets.only(right: 16),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 4,
+                      ),
+                      decoration: BoxDecoration(
+                        color: AppColors.primaryColor,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Text(
+                        '${wish.items.length}',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ],
+                );
+              }
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.favorite_outline,
-              size: 80,
-              color: AppColors.textTertiary,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Your Wishlist',
-              style: TextStyle(
-                color: AppColors.textPrimary,
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
+      body: Consumer<WishlistProvider>(
+        builder: (context, wish, _) {
+          if (!_firstBlockShown && !wish.isLoading) {
+            _firstBlockShown = true;
+          }
+
+          if (!_postFrameChecked && !wish.isLoading) {
+            _postFrameChecked = true;
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!mounted || !_scroll.hasClients) return;
+              final pos = _scroll.position;
+              final viewport = pos.viewportDimension;
+              final needsScrollToGate = viewport * 0.40;
+              final canReachGate = pos.maxScrollExtent >= needsScrollToGate;
+              if (!canReachGate && !_newReady) {
+                setState(() => _newReady = true);
+              }
+            });
+          }
+
+          return CustomScrollView(
+            controller: _scroll,
+            slivers: [
+              if (wish.isLoading)
+                const SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: _LoadingState(),
+                )
+              else ...[
+                if (wish.items.isEmpty) ...[
+                  // Empty state with heart icon and some items section
+                  SliverToBoxAdapter(
+                    child: _EmptyWishlistContent(
+                      heartAnimation: _heartAnimation,
+                      isDark: isDark,
+                    ),
+                  ),
+                ] else ...[
+                  // Wishlist items header
+                  SliverToBoxAdapter(
+                    child: Container(
+                      margin: const EdgeInsets.all(16),
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 12,
+                        horizontal: 16,
+                      ),
+                      decoration: BoxDecoration(
+                        color: isDark
+                            ? AppColors.darkSurfaceColor
+                            : AppColors.surfaceColor,
+                        borderRadius: BorderRadius.circular(12),
+                        boxShadow: [
+                          BoxShadow(
+                            color:
+                                (isDark ? Colors.black : AppColors.lightShadow)
+                                    .withOpacity(0.1),
+                            blurRadius: 6,
+                            offset: const Offset(0, 2),
+                          ),
+                        ],
+                      ),
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.favorite,
+                            color: AppColors.primaryColor,
+                            size: 20,
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            'Saved Items (${wish.items.length})',
+                            style: TextStyle(
+                              color: isDark
+                                  ? AppColors.darkTextPrimary
+                                  : AppColors.textPrimary,
+                              fontSize: 16,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+
+                  // Wishlist items -d and list
+                  SliverPadding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    sliver: SliverList(
+                      delegate: SliverChildBuilderDelegate((context, index) {
+                        final item = wish.items[index];
+                        return _WishlistListCard(
+                          title: item.title,
+                          price: item.price,
+                          thumbnail: item.thumbnail,
+                          isDark: isDark,
+                          onRemove: () => context
+                              .read<WishlistProvider>()
+                              .remove(item.productId),
+                          onOpen: () {
+                            // TODO: Navigate to product detail
+                          },
+                        );
+                      }, childCount: wish.items.length),
+                    ),
+                  ),
+                ],
+
+                // New Items Section
+                SliverToBoxAdapter(
+                  child: Container(
+                    margin: const EdgeInsets.only(top: 24),
+                    child: (wish.items.isEmpty || _newReady)
+                        ? NewItemsSection(
+                            productRepository: _productRepo,
+                            title: 'Discover New Items',
+                            productLimit: 8,
+                            onSeeAllTap: () {},
+                            onProductTap: (p) {},
+                          )
+                        : const SizedBox.shrink(),
+                  ),
+                ),
+
+                // Bottom padding
+                const SliverToBoxAdapter(child: SizedBox(height: 24)),
+              ],
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _EmptyWishlistContent extends StatelessWidget {
+  const _EmptyWishlistContent({
+    required this.heartAnimation,
+    required this.isDark,
+  });
+
+  final Animation<double> heartAnimation;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // Empty state with animated heart
+        Container(
+          height: MediaQuery.of(context).size.height * 0.4,
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  AnimatedBuilder(
+                    animation: heartAnimation,
+                    builder: (context, child) {
+                      return Transform.scale(
+                        scale: heartAnimation.value,
+                        child: Container(
+                          padding: const EdgeInsets.all(20),
+                          decoration: BoxDecoration(
+                            color: AppColors.primaryColor.withOpacity(0.1),
+                            shape: BoxShape.circle,
+                          ),
+                          child: Icon(
+                            Icons.favorite,
+                            size: 60,
+                            color: AppColors.primaryColor,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    'Your Wishlist is Empty',
+                    style: TextStyle(
+                      color: isDark
+                          ? AppColors.darkTextPrimary
+                          : AppColors.textPrimary,
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Save items you love to find them easily later',
+                    style: TextStyle(
+                      color: isDark
+                          ? AppColors.darkTextSecondary
+                          : AppColors.textSecondary,
+                      fontSize: 16,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 24),
+                  ElevatedButton.icon(
+                    onPressed: () => Navigator.of(context).maybePop(),
+                    icon: const Icon(Icons.shopping_bag_outlined),
+                    label: const Text('Start Shopping'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primaryColor,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 32,
+                        vertical: 16,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(25),
+                      ),
+                      elevation: 2,
+                    ),
+                  ),
+                ],
               ),
             ),
-            const SizedBox(height: 8),
-            Text(
-              'Save your favorite items here',
-              style: TextStyle(color: AppColors.textSecondary, fontSize: 16),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _LoadingState extends StatelessWidget {
+  const _LoadingState();
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          CircularProgressIndicator(
+            color: AppColors.primaryColor,
+            strokeWidth: 3,
+          ),
+          const SizedBox(height: 20),
+          Text(
+            'Loading your wishlist...',
+            style: TextStyle(
+              color: isDark
+                  ? AppColors.darkTextSecondary
+                  : AppColors.textSecondary,
+              fontSize: 16,
             ),
-          ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WishlistListCard extends StatelessWidget {
+  const _WishlistListCard({
+    required this.title,
+    required this.price,
+    required this.thumbnail,
+    required this.isDark,
+    required this.onRemove,
+    required this.onOpen,
+  });
+
+  final String title;
+  final double price;
+  final String thumbnail;
+  final bool isDark;
+  final VoidCallback onRemove;
+  final VoidCallback onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: InkWell(
+        onTap: onOpen,
+        borderRadius: BorderRadius.circular(16),
+        child: Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: isDark ? AppColors.darkSurfaceColor : AppColors.surfaceColor,
+            borderRadius: BorderRadius.circular(16),
+            boxShadow: [
+              BoxShadow(
+                color: (isDark ? Colors.black : AppColors.lightShadow)
+                    .withOpacity(0.08),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              // Product Image
+              ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: Container(
+                  width: 80,
+                  height: 80,
+                  child: Image.network(
+                    thumbnail,
+                    fit: BoxFit.cover,
+                    errorBuilder: (_, __, ___) => Container(
+                      color: isDark ? Colors.grey[800] : Colors.grey[200],
+                      child: Icon(
+                        Icons.image_not_supported,
+                        color: isDark ? Colors.grey[600] : Colors.grey[400],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+
+              const SizedBox(width: 12),
+
+              // Product Info
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: TextStyle(
+                        color: isDark
+                            ? AppColors.darkTextPrimary
+                            : AppColors.textPrimary,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 16,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '\$${price.toStringAsFixed(2)}',
+                      style: TextStyle(
+                        color: AppColors.primaryColor,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 18,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              // Actions
+              Column(
+                children: [
+                  IconButton(
+                    onPressed: onRemove,
+                    icon: const Icon(Icons.favorite, color: Colors.red),
+                    tooltip: 'Remove from wishlist',
+                  ),
+                  IconButton(
+                    onPressed: () {
+                      // TODO: Add to cart functionality
+                    },
+                    icon: Icon(
+                      Icons.shopping_cart_outlined,
+                      color: isDark
+                          ? AppColors.darkTextSecondary
+                          : AppColors.textSecondary,
+                    ),
+                    tooltip: 'Add to cart',
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Shows *New Items* **after** the Wishlist grid on the Wishlist screen.
- Provides a single shared **ApiClient** and **ProductRepository** at app root (via Provider + ProxyProvider).
- Lazy-loads *New Items* like Home (appears after user scrolls), with a safe fallback when the page cannot scroll.

## Why
- Reuse a single networking stack across tabs/screens (fewer duplicate instances, consistent headers/caching).
- Keep Wishlist UX consistent with Home while avoiding heavy initial work.
- Ensure *New Items* still render when the wishlist is short/empty and the page can’t reach the scroll threshold.

## What changed
### Dependency injection
- **main.dart**
  - Added:
    - \`Provider<ApiClient>(create: (_) => const ApiClient())\`
    - \`ProxyProvider<ApiClient, ProductRepository>(update: (_, api, prev) => prev ?? ProductRepository(api))\`
  - (Optional pattern ready for more repos via ProxyProvider.)

### Home
- **HomeScreen**
  - Reads the global \`ProductRepository\` via \`context.read<ProductRepository>()\` instead of creating a new instance.

### Wishlist
- **WishlistScreen**
  - Converted to **Stateful**.
  - Reads global \`ProductRepository\` once in \`initState\`.
  - Uses a **CustomScrollView** with Slivers so Wishlist + *New Items* share one scroll.
  - Adds lazy-gating for *New Items* (shows after ~40% viewport scroll), **plus**:
    - Immediate show when wishlist is **empty**.
    - Post-frame **no-scroll fallback** (auto-enables when content cannot reach the threshold).

## How to test
1. Launch app and open **Wishlist**.
2. **Empty wishlist**:
   - Should show the empty state **and** the *New Items* section immediately.
3. **Non-empty wishlist**:
   - Scroll ~40% of the viewport; *New Items* should appear.
4. Confirm *New Items* render correctly and tapping a product can navigate to detail (if wired).
5. Sanity check **Home** still loads with the shared repository (no functional regressions).

## Files (key)
- \`lib/main.dart\` (providers: ApiClient, ProductRepository via ProxyProvider)
- \`lib/presentation/screens/home/home_screen.dart\` (read global repo)
- \`lib/presentation/screens/wishlist/wishlist_screen.dart\` (slivers, lazy gate, fallback)
- \`lib/presentation/widgets/new_items_section.dart\` (used, unchanged)

## Notes
- ProxyProvider keeps repositories in sync with their dependencies and avoids duplicate instances.
- If more repos are needed (e.g., CategoryRepository), follow the same ProxyProvider pattern.